### PR TITLE
Feat/skip genres

### DIFF
--- a/clean-version/src/components/Player/Player.jsx
+++ b/clean-version/src/components/Player/Player.jsx
@@ -13,6 +13,7 @@ import { ReactComponent as DeviceIcon } from '../../images/devices.svg'
 import { ReactComponent as PlaylistsIcon } from '../../images/playlists.svg'
 import { ReactComponent as TopListsIcon } from '../../images/user-top-lists.svg'
 import { ReactComponent as StatsIcon } from '../../images/stats.svg'
+import { ReactComponent as SkipIcon } from '../../images/skip.svg'
 import ActionButton from 'components/common/ActionButton'
 
 const noBorderTop = {
@@ -59,6 +60,14 @@ const PlayerAPI = () => {
           tooltip="Show stats for current song"
           action={() => {
             dispatch({ type: 'visible/toggle-stats' })
+          }}
+          className={`device-button pointer ${touched}`}
+        />
+        <ActionButton
+          Icon={() => <SkipIcon height={24} wdith={24} />}
+          tooltip="Show the Skip List"
+          action={() => {
+            dispatch({ type: 'visible/toggle-skipList' })
           }}
           className={`device-button pointer ${touched}`}
         />

--- a/clean-version/src/components/skip-list/SkipList.jsx
+++ b/clean-version/src/components/skip-list/SkipList.jsx
@@ -261,9 +261,10 @@ const withData = () => {
     addToSkipList,
     removeFromSkipList,
     toggleSkipList,
+    isVisible,
   } = useSkipTrack()
 
-  return (
+  return isVisible ? (
     <>
       <DragBox>
         <SkipList
@@ -278,7 +279,7 @@ const withData = () => {
         />
       </DragBox>
     </>
-  )
+  ) : null
 }
 
 export default memo(withData)

--- a/clean-version/src/globalContext.jsx
+++ b/clean-version/src/globalContext.jsx
@@ -13,6 +13,7 @@ const initalState = {
     topTable: false,
     devices: false,
     stats: false,
+    skipList: false,
   },
   searchQuery: {
     type: '',
@@ -43,6 +44,7 @@ const initalState = {
 export const GlobalContext = createContext(initalState)
 
 function reducer(state, action) {
+  console.log(action)
   switch (action.type) {
     case 'user/loginSpotify':
       return {
@@ -96,6 +98,15 @@ function reducer(state, action) {
           stats: !state.visible.stats,
         },
       }
+
+    case 'visible/toggle-skipList':
+      return {
+        ...state,
+        visible: {
+          ...state.visible,
+          skipList: !state.visible.skipList,
+        },
+      }
     case 'search/set':
       return {
         ...state,
@@ -146,7 +157,6 @@ function reducer(state, action) {
           ...state.skipList,
         },
       }
-
     default:
       return state
   }

--- a/clean-version/src/hooks/useSkipTrack.jsx
+++ b/clean-version/src/hooks/useSkipTrack.jsx
@@ -5,7 +5,13 @@ import { GlobalContext } from '../globalContext'
 
 export const useSkipTrack = () => {
   const currentTrack = useContext(CurrentPlayingContext)
-  const [{ skipList }, dispatch] = useContext(GlobalContext)
+  const [
+    {
+      skipList,
+      visible: { skipList: isVisible },
+    },
+    dispatch,
+  ] = useContext(GlobalContext)
   const addToSkipList = (skipType, id) => {
     dispatch({
       type: 'skipList/add',
@@ -84,5 +90,6 @@ export const useSkipTrack = () => {
     removeFromSkipList,
     toggleSkipList,
     skipList,
+    isVisible,
   }
 }

--- a/clean-version/src/images/skip.svg
+++ b/clean-version/src/images/skip.svg
@@ -1,31 +1,28 @@
 
 <svg
-  style="height: 24px;width: 24px; 
-  
-
-  margin-top: 150px;  margin-left: 500px; 
-  
-  background: black;"
+  style="height: 24px;width: 24px; "
 
 
   stroke-linecap="round"
   stroke-width="1px"
-  viewBox="0 0 24 28" fill="#1db954" stroke="#fff"
+  viewBox="0 0 24 28" 
+  
+  opactity="0.8" fill="#FFF" stroke="#000"
   
   
   xmlns="http://www.w3.org/2000/svg" >
   <!-- surely browsers are not so antiquated -->
  
 
-	<polygon stroke="#1db954"
+	<polygon fill="#FFF"
 		points="0,0 0,23 14,12"
 	/>
   
-    <polygon stroke="#1db954"
+    <polygon fill="#FFF"
 		data-points="14,2 14,21 28,12" data-left="x-4"
 		points="10,2 10,21 26,12" 
 	/> 
-  <rect stroke="#1db954"
+  <rect fill="#FFF"
     x="17" y="2" width="7" height="20" 
   />
 </svg>

--- a/clean-version/src/styles/components/_SkipList.scss
+++ b/clean-version/src/styles/components/_SkipList.scss
@@ -5,7 +5,7 @@
   left: $sm;
   width: 300px;
   z-index: 3;
-  border: inset 1px solid $spotify-white;
+  border: 1px solid $spotify-white;
 
   border-radius: $md;
 


### PR DESCRIPTION
feature(SKIP-LIST): expose ids of genres, and artists to a blocklist known as the skipList.
    
    - The Skip List is checked as a new song starts.
    - When the {id - name} matches an entry from Sets saved in the reducer, the action "/me/player/next" is triggered.
    - A copy is kept in localStorage under the key prefix "skipList.", genres, artists, tracks, and active are the skipTypes.